### PR TITLE
Adding functionality for visa expiry date to only show when citizensh…

### DIFF
--- a/taworks/taform/models.py
+++ b/taworks/taform/models.py
@@ -24,7 +24,7 @@ class Student(models.Model):
     RESIDENTIAL_STATUS = (('canadian citizen', 'Canadian Citizen/Permanent Resident'), ('student visa', 'Student Visa'))
     citizenship = models.CharField(null=False, max_length=50, choices=RESIDENTIAL_STATUS)
     student_visa_expiry_date = models.DateField(null=True, blank=True,
-        help_text="Only fill in this field if your citizenship is 'Student Visa' (yyyy-mm-dd).")
+        help_text="Must be in form: yyyy-mm-dd")
     ENROLLED = (('full time', 'Full-Time'), ('part time', 'Part-Time'), ('other', 'Other'))
     enrolled_status = models.CharField(max_length=50, choices=ENROLLED)
     ta_expectations = models.BooleanField(default=False, blank=True)

--- a/taworks/taform/static/taform/js/app.js
+++ b/taworks/taform/static/taform/js/app.js
@@ -14,8 +14,8 @@ function noBack() {
 //Function to make the student visa expiry date input hidden unless citizenship=student visa
 function visaFunction() {
 	var visaSelect = document.getElementById("id_citizenship");
-	var strvisaSelect = visaSelect.options[visaSelect.selectedIndex].text;
-	if(strvisaSelect == "Student Visa"){
+	var strVisaSelect = visaSelect.options[visaSelect.selectedIndex].text;
+	if(strVisaSelect == "Student Visa"){
 		document.getElementById("expiryInput").hidden=false;
 		document.getElementById("visaID").hidden=false;
 		document.getElementById("expiryDate").hidden=false;

--- a/taworks/taform/static/taform/js/app.js
+++ b/taworks/taform/static/taform/js/app.js
@@ -11,3 +11,18 @@ function checkboxFunction() {
 function noBack() {
     window.history.forward();
 }
+//Function to make the student visa expiry date input hidden unless citizenship=student visa
+function visaFunction() {
+	var visaSelect = document.getElementById("id_citizenship");
+	var strvisaSelect = visaSelect.options[visaSelect.selectedIndex].text;
+	if(strvisaSelect == "Student Visa"){
+		document.getElementById("expiryInput").hidden=false;
+		document.getElementById("visaID").hidden=false;
+		document.getElementById("expiryDate").hidden=false;
+	}
+	else{
+		document.getElementById("expiryInput").hidden=true;
+		document.getElementById("visaID").hidden=true;
+		document.getElementById("expiryDate").hidden=true;
+	}
+}

--- a/taworks/taform/templates/taform/application.html
+++ b/taworks/taform/templates/taform/application.html
@@ -97,13 +97,12 @@ employment as a teaching assistant:</p>
     </tr>
     <tr>
         <td>Citizenship:</td>
-        <td>{{s_form.citizenship}}</td>
-        <td>{{s_form.citizenship.help_text}}</td>
+        <td><label onchange="visaFunction();">{{s_form.citizenship}}</label></td>
     </tr>
     <tr>
-        <td>Student Visa Expiry Date:</td>
-        <td>{{s_form.student_visa_expiry_date}}</td>
-        <td>{{s_form.student_visa_expiry_date.help_text}}</td>
+        <td><label hidden id="visaID">Student Visa Expiry Date:</label></td>
+        <td id="expiryInput" hidden>{{s_form.student_visa_expiry_date}}</td>
+        <td id="expiryDate" hidden>{{s_form.student_visa_expiry_date.help_text}}</td>
     </tr>
     <tr>
         <td>Enrollment:</td>


### PR DESCRIPTION
changed: 

- html tags <label> and <td> are used to store event handlers and hidden option
- model for student_visa_expiry_date help text is changed to remove "only fill in when..." to "form must be yyyy-mm-dd"
- tested on safari and chrome
- tested for saving application to db on local - student visa and non student visa