### PR TITLE
adding django-access-tokens to the requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django==1.11.2
 Pillow==5.0.0
 WhiteNoise==3.3.1
 psycopg2==2.7.3.2
+django-access-tokens==0.9.2


### PR DESCRIPTION
![screen shot 2018-01-20 at 9 33 15 pm](https://user-images.githubusercontent.com/22120696/35190303-f63784a8-fe2b-11e7-94a5-de3651affd08.png)


based on what I googled - the pip install should be:

**pip install django-access-tokens**

I tested to make sure that the url hash was made after making this installation:

![screen shot 2018-01-20 at 9 51 54 pm](https://user-images.githubusercontent.com/22120696/35190314-29284dde-fe2c-11e7-94b1-f653b741dc02.png)
