### PR TITLE
Making /taform/  go to intro page first

### DIFF
--- a/taworks/taform/templates/taform/application.html
+++ b/taworks/taform/templates/taform/application.html
@@ -11,7 +11,7 @@
 </div>
 {% load taform_extras %}
 
-<form enctype="multipart/form-data" autocomplete="off" action="." method="POST" accept-charset="utf-8" >
+<form enctype="multipart/form-data" autocomplete="off" action="{% url 'application' %}" method="POST" accept-charset="utf-8" >
 
 {% csrf_token %}
 <font class="font">{{error}}</font>

--- a/taworks/taform/templates/taform/intro.html
+++ b/taworks/taform/templates/taform/intro.html
@@ -66,7 +66,7 @@ preferences, but ultimately, TA positions are awarded based on many factors:</p>
     that the Study Permit has not expired or will not expire during the period 
     of the Teaching Assistantship.  Please see the following website for more 
     information regarding renewal of <a target="_blank" 
-    href=https://uwaterloo.ca/graduate-studies/course-enrolment/immigration-status-changes>
+    href=https://uwaterloo.ca/graduate-studies/current-students/update-your-immigration-status>
     Study Permits or Immigration Status changes</a>.</li>
 </ul>
 

--- a/taworks/taform/urls.py
+++ b/taworks/taform/urls.py
@@ -4,7 +4,7 @@ from django.conf.urls.static import static
 from django.conf import settings
 
 urlpatterns = [
-    url(r'^$', views.intro, name='firstPage'),
+    url(r'^$', views.intro, name='introPage'),
     url(r'application.html', views.apply, name='application'),
     url(r'application_submitted.html', views.application_submitted, name='application_submitted'),
     url(r'course_list.html', views.course_list, name='course_list'),

--- a/taworks/taform/urls.py
+++ b/taworks/taform/urls.py
@@ -4,7 +4,7 @@ from django.conf.urls.static import static
 from django.conf import settings
 
 urlpatterns = [
-    url(r'^$', views.apply, name='apply'),
+    url(r'^$', views.intro, name='firstPage'),
     url(r'application.html', views.apply, name='application'),
     url(r'application_submitted.html', views.application_submitted, name='application_submitted'),
     url(r'course_list.html', views.course_list, name='course_list'),

--- a/taworks/taform/views.py
+++ b/taworks/taform/views.py
@@ -148,7 +148,7 @@ def login(request):
 
 def intro(request): 
     if request.method == 'POST':
-        return render(request, 'taform/application.html')
+        return HttpResponseRedirect('application.html')    
     return render(request, 'taform/intro.html')  
 
 def apply(request):


### PR DESCRIPTION
Changes for PR:
**application.html**: had to change action to reference the url as it is no longer the origin page
**intro.html**: the one link was expired so updated to the new one
**urls.py**:  changed base page from application page to the intro page
**views.py**: changed post return to http redirect as no context needs to be passed through to application page

Testing:
- made sure that ever link still works on local
- made sure DB gets updated on application submit from both AC view (logged in - no intro page) and TA view (logged out - intro page)