### PR TITLE
Adding Student Preference to Application

### DIFF
--- a/taworks/taform/models.py
+++ b/taworks/taform/models.py
@@ -30,9 +30,7 @@ class Student(models.Model):
     ta_expectations = models.BooleanField(default=False, blank=True)
     cv = models.FileField(upload_to='documents/', null=True, blank=True)
     full_ta = models.BooleanField(default=False, blank=True)
-    three_quarter_ta = models.BooleanField(default=False, blank=True)
     half_ta = models.BooleanField(default=False, blank=True)
-    quarter_ta = models.BooleanField(default=False, blank=True)
 
 class Course(models.Model):
     term = models.PositiveIntegerField(validators=[MaxValueValidator(9999), MinValueValidator(1000)], null=True)

--- a/taworks/taform/templates/taform/application.html
+++ b/taworks/taform/templates/taform/application.html
@@ -68,7 +68,12 @@
         <td>{{s_form.ta_expectations}}&nbsp;Yes</td>
         <td>{{s_form.ta_expectations.help_text}}</td> 
      </tr>
+     <tr>
+        <td>Preference of Position Type (select all that apply):</td>
+        <td>{{s_form.full_ta}}&nbsp;Full TA&emsp;{{s_form.half_ta}}&nbsp;1/2 TA</td>
+    </tr>
 </table>
+        &emsp;&emsp;<b>Please note: preferences are taken into consideration but are not guaranteed.</b>
 
 <h3>CV Upload</h3>
 To help instructors select TAs, please upload a CV or resume (PDF only):<br><br>

--- a/taworks/taform/templates/taform/application.html
+++ b/taworks/taform/templates/taform/application.html
@@ -70,7 +70,7 @@
      </tr>
      <tr>
         <td>Preference of Position Type (select all that apply):</td>
-        <td>{{s_form.full_ta}}&nbsp;Full TA&emsp;{{s_form.half_ta}}&nbsp;1/2 TA</td>
+        <td>{{s_form.full_ta}}&nbsp;Full TA&emsp;{{s_form.half_ta}}&nbsp;Half TA</td>
     </tr>
 </table>
         &emsp;&emsp;<b>Please note: preferences are taken into consideration but are not guaranteed.</b>


### PR DESCRIPTION
Changes this PR:
**models.py**: removing 3/4 and 1/4 ta from database as this will only confuse people and we will not use in the future
**application.html**:adding checkboxes for both full and half ta - made it clear that this is only for consideration and no guarantee

Testing: 
Tested that if both, none, one or the other are selected, it will save to DB:

![screen shot 2018-02-01 at 3 25 12 pm](https://user-images.githubusercontent.com/22120696/35701646-9ce17426-0764-11e8-963f-f49ba7c5fe70.png)
