### PR TITLE
Changing drop down for preference in app table to text only

### DIFF
--- a/taworks/taform/models.py
+++ b/taworks/taform/models.py
@@ -60,7 +60,8 @@ class Application(models.Model):
     student = models.ForeignKey(Student, on_delete=models.CASCADE, blank=True)
     course = models.ForeignKey(Course, on_delete=models.CASCADE, blank=True)
     application_date = models.DateTimeField(auto_now_add=True)
-    preference = models.IntegerField(validators=[MaxValueValidator(3), MinValueValidator(0)])
+    STUDENT_PREFERENCE = ((1,'I prefer to TA this course'),(2,'I am able to TA this course'),(3,'I would prefer not to TA this course'),(0,'I am unable to TA this course'))
+    preference = models.CharField(max_length=50, choices=STUDENT_PREFERENCE)
     reason = models.CharField(max_length=255, null=True, blank=True)
     ratings = ((1,'1-Most Preferred'),(2,'2'),(3,'3'),(4,'4'),(5,'5-Least Preferred'),(0,'0-Not a Match'))
     instructor_preference = models.IntegerField(null=True,choices=ratings, 

--- a/taworks/taform/models.py
+++ b/taworks/taform/models.py
@@ -61,7 +61,7 @@ class Application(models.Model):
     course = models.ForeignKey(Course, on_delete=models.CASCADE, blank=True)
     application_date = models.DateTimeField(auto_now_add=True)
     STUDENT_PREFERENCE = ((1,'I prefer to TA this course'),(2,'I am able to TA this course'),(3,'I would prefer not to TA this course'),(0,'I am unable to TA this course'))
-    preference = models.CharField(max_length=50, choices=STUDENT_PREFERENCE)
+    preference = models.IntegerField(choices=STUDENT_PREFERENCE)
     reason = models.CharField(max_length=255, null=True, blank=True)
     ratings = ((1,'1-Most Preferred'),(2,'2'),(3,'3'),(4,'4'),(5,'5-Least Preferred'),(0,'0-Not a Match'))
     instructor_preference = models.IntegerField(null=True,choices=ratings, 

--- a/taworks/taform/static/taform/css/style.css
+++ b/taworks/taform/static/taform/css/style.css
@@ -90,7 +90,7 @@ table {
     } 
 
 .pref_class {
-    width: 200px;
+    width: 225px;
 }
 
 textarea {

--- a/taworks/taform/static/taform/css/style.css
+++ b/taworks/taform/static/taform/css/style.css
@@ -90,7 +90,7 @@ table {
     } 
 
 .pref_class {
-    width: 30px;
+    width: 200px;
 }
 
 textarea {

--- a/taworks/taform/templates/taform/application.html
+++ b/taworks/taform/templates/taform/application.html
@@ -126,9 +126,9 @@ To help instructors select TAs, please upload a CV or resume (PDF only):<br><br>
 
     <p>For each course, please enter your preference. See the options below for details:</p>
     <ul>
-        <li>I prefer to teach this course</li>
-        <li>I am able to teach this course</li>
-        <li>I would prefer not to teach this course</li>
+        <li>I prefer to TA this course</li>
+        <li>I am able to TA this course</li>
+        <li>I would prefer not to TA this course</li>
         <li>I am unable to TA this course</li>
     </ul>
 </div>

--- a/taworks/taform/templates/taform/application.html
+++ b/taworks/taform/templates/taform/application.html
@@ -124,12 +124,12 @@ To help instructors select TAs, please upload a CV or resume (PDF only):<br><br>
     that you are available for all of the TA requirements by reviewing the 
     schedule for each course before applying. <p>
 
-    <p>For each course, please enter your preference. See the legend below for details:</p>
+    <p>For each course, please enter your preference. See the options below for details:</p>
     <ul>
-        <li> <b>1:</b> I prefer to teach this course</li>
-        <li> <b>2:</b> I am able to teach this course</li>
-        <li> <b>3:</b> I would prefer not to teach this course</li>
-        <li> <b>0:</b> I am unable to TA this course</li>
+        <li>I prefer to teach this course</li>
+        <li>I am able to teach this course</li>
+        <li>I would prefer not to teach this course</li>
+        <li>I am unable to TA this course</li>
     </ul>
 </div>
 


### PR DESCRIPTION
Changes in PR:

**models.py**: changing the field type for preference to be a drop down
**style.css**: changing the width of the output to be large enough to show all text
**application.html**: removing the numbers from the legend so we dont confuse people