### PR TITLE
Show Ranking Status email after emails sent

### DIFF
--- a/taworks/taform/views.py
+++ b/taworks/taform/views.py
@@ -36,10 +36,6 @@ def postpone(function):
 def ranking_status(request):
     if not request.user.is_authenticated:
         return redirect('login')
-    elif 'Upload' in request.POST:
-        email_ranking_links()
-        return render(request, 'taform/ranking_status.html', 
-            {'success': 'Ranking email links have been sent.', 'sent': True })
 
     ranking_status = list(models.Application.objects.values('course__course_id', 
         'course__section', 'course__instructor_name', 'course__instructor_email', 
@@ -55,6 +51,15 @@ def ranking_status(request):
             r['status']='Not Submitted'
         else:
             r['status']='Submitted'
+
+    if 'Upload' in request.POST:
+        email_ranking_links()
+        context = {
+        'success' : 'Ranking email links have been sent.',
+        'sent' :True,
+        'ranking_status' : ranking_status,
+        }
+        return render(request, 'taform/ranking_status.html', context)
 
     context = {
         'sent' : False,


### PR DESCRIPTION
Changes for PR:

**views.py**: changing location of query so each hit will run through it unless not authenticated. Removed elif & changed to if so it would run through query. Added context reference to If upload return

Testing:

Table shows on first view: 
![screen shot 2018-02-07 at 9 25 48 pm](https://user-images.githubusercontent.com/22120696/35952446-f4d227b4-0c4d-11e8-965e-f9407ed2201f.png)
table shows after sending emails:
![screen shot 2018-02-07 at 9 26 03 pm](https://user-images.githubusercontent.com/22120696/35952448-03a1727c-0c4e-11e8-98a0-7a4e62902f56.png)
Emails get sent!
![screen shot 2018-02-07 at 9 29 04 pm](https://user-images.githubusercontent.com/22120696/35952452-08c6ed5e-0c4e-11e8-9d44-a2edce2c1a2f.png)
