### PR TITLE
Resume hash

### DIFF
--- a/taworks/taform/urls.py
+++ b/taworks/taform/urls.py
@@ -18,7 +18,8 @@ urlpatterns = [
     url(r'upload_front_matter.html', views.upload_front_matter, name='upload_front_matter'),
     url(r'ranking_status.html', views.ranking_status, name='ranking_status'),
     url(r'preference_submitted.html', views.preference_submitted, name='preference_submitted'),
-    url(r'export.html', views.export, name='export')
+    url(r'export.html', views.export, name='export'),
+    url(r'resume.html', views.resume_view, name='pdf')    
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/taworks/taform/views.py
+++ b/taworks/taform/views.py
@@ -376,6 +376,17 @@ def assign_tas(request):
     }
     return render(request, 'taform/number_tas.html', context)
 
+def resume_view(path):
+    my_path = os.path.abspath(os.path.dirname(__file__))
+    path = my_path + "/../media/documents/JohnsonKan_tcps2_core_certificate_AVMcNTl.pdf"
+    print path
+    with open(path, 'r') as pdf:
+        response = HttpResponse(pdf.read(), content_type='application/pdf')
+        response['Content-Disposition'] = 'inline;filename=student name??.pdf'
+        return response
+    pdf.closed
+
+
 def upload_front_matter(request):
     if not request.user.is_authenticated:
         return redirect('login')

--- a/taworks/taform/views.py
+++ b/taworks/taform/views.py
@@ -402,16 +402,14 @@ def assign_tas(request):
     }
     return render(request, 'taform/number_tas.html', context)
 
-def resume_view(path):
+def resume_view(student_cv_url):
     my_path = os.path.abspath(os.path.dirname(__file__))
-    path = my_path + "/../media/documents/JohnsonKan_tcps2_core_certificate_AVMcNTl.pdf"
-    print path
+    path = my_path + "/media/documents/" + student_cv_url
     with open(path, 'r') as pdf:
         response = HttpResponse(pdf.read(), content_type='application/pdf')
         response['Content-Disposition'] = 'inline;filename=student name??.pdf'
         return response
     pdf.closed
-
 
 def upload_front_matter(request):
     if not request.user.is_authenticated:

--- a/taworks/taform/views.py
+++ b/taworks/taform/views.py
@@ -407,7 +407,7 @@ def resume_view(student_cv_url):
     path = my_path + "/media/documents/" + student_cv_url
     with open(path, 'r') as pdf:
         response = HttpResponse(pdf.read(), content_type='application/pdf')
-        response['Content-Disposition'] = 'inline;filename=student name??.pdf'
+        response['Content-Disposition'] = 'inline;filename=' + student_cv_url
         return response
     pdf.closed
 


### PR DESCRIPTION
this is just the api for viewing resume. 

it's not integrated with instructor ranking page because there's currently an unknown bug on that page and it''s better not to add more logic to it.

but with that being said, i can demo how this works during monday stand up.

the idea is to leverage this behind the course token instead of generating another token for each student resume.

1) just going to team4.uwaterloo.ca/taform/resume.html should yield nothing
2) it should be a form action for each student in the list to call the views method that then calls this resume_view function which will then open up a new page with the students resume. (The url would still appear as resume.html tho).
