### PR TITLE
Changing success messages to green

### DIFF
--- a/taworks/taform/static/taform/css/style.css
+++ b/taworks/taform/static/taform/css/style.css
@@ -73,7 +73,7 @@ p, ul, ol, body, div p, div ul {
 .submitButton:hover {
     opacity: 1
 }
-#successMessage {
+.successMessage {
     color: #00b300;
     font-family: 'Roboto';
     font-weight: 700;

--- a/taworks/taform/static/taform/css/style.css
+++ b/taworks/taform/static/taform/css/style.css
@@ -73,10 +73,10 @@ p, ul, ol, body, div p, div ul {
 .submitButton:hover {
     opacity: 1
 }
-#p01 {
-    color: red;
+#successMessage {
+    color: #00b300;
     font-family: 'Roboto';
-    font-weight: 400;
+    font-weight: 700;
     font-style: normal;
 }
 .green_txt {

--- a/taworks/taform/templates/taform/algorithm.html
+++ b/taworks/taform/templates/taform/algorithm.html
@@ -6,11 +6,11 @@
 <h1>Teaching Assistant Assignment</h1>
 <p>Run the follow to output the graduate student to course assignements.</p> 
 <p><b>Please note:</b> for the most accurate results ensure the number of TA's per course are correct and that all Instructors have submitted their rankings.</p>
-<p id="successMessage">{{no_apps_error}}</p>
-<p id="successMessage">{{no_results_error}}</p>
-<p id="successMessage">{{no_results_error_1}}</p>
-<p id="successMessage">{{no_results_error_2}}</p>
-<p id="successMessage">{{no_results_error_3}}</p>
+<p class="successMessage">{{no_apps_error}}</p>
+<p class="successMessage">{{no_results_error}}</p>
+<p class="successMessage">{{no_results_error_1}}</p>
+<p class="successMessage">{{no_results_error_2}}</p>
+<p class="successMessage">{{no_results_error_3}}</p>
 
 <table class="tg">
     <tr>

--- a/taworks/taform/templates/taform/algorithm.html
+++ b/taworks/taform/templates/taform/algorithm.html
@@ -6,11 +6,11 @@
 <h1>Teaching Assistant Assignment</h1>
 <p>Run the follow to output the graduate student to course assignements.</p> 
 <p><b>Please note:</b> for the most accurate results ensure the number of TA's per course are correct and that all Instructors have submitted their rankings.</p>
-<p id="p01">{{no_apps_error}}</p>
-<p id="p01">{{no_results_error}}</p>
-<p id="p01">{{no_results_error_1}}</p>
-<p id="p01">{{no_results_error_2}}</p>
-<p id="p01">{{no_results_error_3}}</p>
+<p id="successMessage">{{no_apps_error}}</p>
+<p id="successMessage">{{no_results_error}}</p>
+<p id="successMessage">{{no_results_error_1}}</p>
+<p id="successMessage">{{no_results_error_2}}</p>
+<p id="successMessage">{{no_results_error_3}}</p>
 
 <table class="tg">
     <tr>

--- a/taworks/taform/templates/taform/application.html
+++ b/taworks/taform/templates/taform/application.html
@@ -209,7 +209,7 @@ Sciences Teaching Assistantship please read in full
 
 <p><b>To submit your application you must agree to the above terms.</b></p>
 
-<p id="p01">Please note you will not be able to make changes to your application once you submit.<p>
+<p id="font">Please note you will not be able to make changes to your application once you submit.<p>
 <input type="submit" class="submitButton" id ="btn" value="Submit" disabled>
 </form>
 

--- a/taworks/taform/templates/taform/instructor_ranking.html
+++ b/taworks/taform/templates/taform/instructor_ranking.html
@@ -38,7 +38,7 @@
 <br>
 
 {% if is_ranking_submitted %}
-  <div id="successMessage">{{success}}</div>
+  <div class="successMessage">{{success}}</div>
   <div> 
   Latest submission: {{updated_at.month}}/{{updated_at.day}}/{{updated_at.year}}, {{updated_at.hour}}:{{updated_at.minute}}:{% if updated_at.second < 10 %}0{{updated_at.second}} 
   {% else %}{{updated_at.second}} 

--- a/taworks/taform/templates/taform/instructor_ranking.html
+++ b/taworks/taform/templates/taform/instructor_ranking.html
@@ -38,7 +38,7 @@
 <br>
 
 {% if is_ranking_submitted %}
-  <div id="font">{{success}}</div>
+  <div id="successMessage">{{success}}</div>
   <div> 
   Latest submission: {{updated_at.month}}/{{updated_at.day}}/{{updated_at.year}}, {{updated_at.hour}}:{{updated_at.minute}}:{% if updated_at.second < 10 %}0{{updated_at.second}} 
   {% else %}{{updated_at.second}} 

--- a/taworks/taform/templates/taform/number_tas.html
+++ b/taworks/taform/templates/taform/number_tas.html
@@ -11,7 +11,7 @@
 <h1>Assign the Number of TAs Required per Course</h1>
 
 {% if is_ranking_submitted %}
-	<div id="successMessage">{{success}}</div>
+	<div class="successMessage">{{success}}</div>
 	<div> 
 	Latest submission: {{updated_at.month}}/{{updated_at.day}}/{{updated_at.year}}, {{updated_at.hour}}:{{updated_at.minute}}:{% if updated_at.second < 10 %}0{{updated_at.second}} 
 	{% else %}{{updated_at.second}} 

--- a/taworks/taform/templates/taform/number_tas.html
+++ b/taworks/taform/templates/taform/number_tas.html
@@ -11,7 +11,7 @@
 <h1>Assign the Number of TAs Required per Course</h1>
 
 {% if is_ranking_submitted %}
-	<div id="font">{{success}}</div>
+	<div id="successMessage">{{success}}</div>
 	<div> 
 	Latest submission: {{updated_at.month}}/{{updated_at.day}}/{{updated_at.year}}, {{updated_at.hour}}:{{updated_at.minute}}:{% if updated_at.second < 10 %}0{{updated_at.second}} 
 	{% else %}{{updated_at.second}} 

--- a/taworks/taform/templates/taform/ranking_status.html
+++ b/taworks/taform/templates/taform/ranking_status.html
@@ -5,7 +5,7 @@
 
 <h1>Ranking Status</h1>
 
-<div id="successMessage">{{success}}</div>
+<div class="successMessage">{{success}}</div>
 
 <h4>Below is a listing of the status of graduate student rankings for the upcoming term's courses.</h4> 
 <p>Rankings that have been submitted can still be edited by the AC. Click on the course link to view and edit Instructor rankings.</p>

--- a/taworks/taform/templates/taform/ranking_status.html
+++ b/taworks/taform/templates/taform/ranking_status.html
@@ -5,7 +5,7 @@
 
 <h1>Ranking Status</h1>
 
-<div id="font">{{success}}</div>
+<div id="successMessage">{{success}}</div>
 
 <h4>Below is a listing of the status of graduate student rankings for the upcoming term's courses.</h4> 
 <p>Rankings that have been submitted can still be edited by the AC. Click on the course link to view and edit Instructor rankings.</p>

--- a/taworks/taform/templates/taform/upload_front_matter.html
+++ b/taworks/taform/templates/taform/upload_front_matter.html
@@ -5,7 +5,7 @@
 
 <h1>Upload Front Matter</h1>
 
-<div id="font">{{success}}</div>
+<div id="successMessage">{{success}}</div>
 <div id="font">{{error}}</div>
 <p> Please ensure the file you upload is a text file (only .txt files will be uploaded). This file should contain HTML syntax. </p>
 <p> Click <a href="../../static/taform/front_matter.txt" download="front_matter.txt">here</a> for the current front matter. </p>

--- a/taworks/taform/templates/taform/upload_front_matter.html
+++ b/taworks/taform/templates/taform/upload_front_matter.html
@@ -5,7 +5,7 @@
 
 <h1>Upload Front Matter</h1>
 
-<div id="successMessage">{{success}}</div>
+<div class="successMessage">{{success}}</div>
 <div id="font">{{error}}</div>
 <p> Please ensure the file you upload is a text file (only .txt files will be uploaded). This file should contain HTML syntax. </p>
 <p> Click <a href="../../static/taform/front_matter.txt" download="front_matter.txt">here</a> for the current front matter. </p>


### PR DESCRIPTION
As per feedback from Olga - success messages should be green. 
Seems super intuitive so went ahead and changed on the pages we give success messages.

example : 
![screen shot 2018-02-26 at 9 19 50 pm](https://user-images.githubusercontent.com/22120696/36707329-d64adb86-1b3b-11e8-9f26-b77dc1602f90.png)
![screen shot 2018-02-26 at 9 20 53 pm](https://user-images.githubusercontent.com/22120696/36707332-d80065ae-1b3b-11e8-9614-2099ab2fe8cf.png)

