### PR TITLE
found ranking status page bug when sending emails

### DIFF
--- a/taworks/taform/views.py
+++ b/taworks/taform/views.py
@@ -83,7 +83,10 @@ def ranking_status(request):
         'success' : 'Ranking email links have been sent.',
         'sent' :True,
         'ranking_status' : ranking_status,
-        'AC' : AC
+        'AC' : AC,
+        'emptyCourses' : emptyCourses,
+        'noApps': noApps,
+        'courses': courses,
         }
         return render(request, 'taform/ranking_status.html', context)
 


### PR DESCRIPTION
table wasnt showing up when there were no applicants because I didn't add the vars to the other context for post

LOL OOPS - fixed
![screen shot 2018-03-08 at 10 26 27 pm](https://user-images.githubusercontent.com/22120696/37188998-08fd9410-2320-11e8-8ca2-5abde3babfa7.png)
