### PR TITLE
centered popups

### DIFF
--- a/taworks/taform/static/taform/css/style.css
+++ b/taworks/taform/static/taform/css/style.css
@@ -105,7 +105,6 @@ p, ul, ol, body, div p, div ul {
     margin-top: 10px;
     opacity: 0.6;
     transition: 0.3s;
-    display: inline-block;
     text-decoration: none;
     cursor: pointer;
 }

--- a/taworks/taform/static/taform/js/app-jquery.js
+++ b/taworks/taform/static/taform/js/app-jquery.js
@@ -9,6 +9,11 @@ $(document).ready(function() {
       autoOpen: false,
       modal: true,
       closeOnEscape: true,
+      position: {
+         my: "center bottom",
+         at: "center center",
+         of: $("#algo-run")
+      },
       buttons: {
           "Yes": function() {
               $( this ).dialog( "close" );
@@ -31,6 +36,11 @@ $(document).ready(function() {
       autoOpen: false,
       modal: true,
       closeOnEscape: true,
+      position: {
+         my: "center bottom",
+         at: "center center",
+         of: $("#ranking")
+      },
       buttons: {
           "Yes": function() {
               $( this ).dialog( "close" );
@@ -53,6 +63,11 @@ $(document).ready(function() {
       autoOpen: false,
       modal: true,
       closeOnEscape: true,
+      position: {
+         my: "center bottom",
+         at: "center top",
+         of: $("#confirm-boxes")
+      },
       buttons: {
         "Yes": function(){
           $( this ).dialog ( "close" );

--- a/taworks/taform/templates/taform/algorithm.html
+++ b/taworks/taform/templates/taform/algorithm.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 {% extends "taform/base.html" %}
 {% block content %}
 {% load static %}
@@ -31,48 +30,49 @@
 </table>
 <p class="successMessage">{{success}}</p>
 <br></br>
-
-<table class="tg">
-    <tr>
-        <td>1. Run the algorithm to see teaching assistant to course assignments.&emsp;</td>
-        <td>
-        <form action="{% url 'algorithm' %}" method="post">
-        {% csrf_token %}
-        <div id="dialog-confirm" title="Confirm Action">
-        <p><span class="emailButtonPopupText"></span>Running the algorithm may take up to 1 minute. Are you sure?</p>
-        </div>
-            <input class="submitButton2Popup" type="submit" name="algo_run" value="Solve model"/>
-        </form>
-        </td>
-    </tr>
-    <tr>
-        <td>2. Export students without a position.&emsp;</td>
-        <td>
-        <form action="{% url 'algorithm' %}" method="post">
-        {% csrf_token %}
-            <input class="submitButton2" type="submit" name="student_export" value="Export students without a match"/>
-        </form>
-        </td>
-    </tr>
-    <tr>
-        <td>3. Export courses that still need teaching assistants.&emsp;</td>
-        <td>
-        <form action="{% url 'algorithm' %}" method="post">
-        {% csrf_token %}
-            <input class="submitButton2" type="submit" name="course_export" value="Export courses without a match"/>
-        </form>
-        </td>
-    </tr>
-    <tr>
-        <td>4. Export matching results.&emsp;</td>
-        <td>
-        <form action="{% url 'algorithm' %}" method="post">
-        {% csrf_token %}
-            <input class="submitButton2" type="submit" name="algo_export" value="Export last algorithm run"/>
-        </form>
-        </td>
-    </tr>
-</table>
+<div id="algo-run">
+    <table class="tg">
+        <tr>
+            <td>1. Run the algorithm to see teaching assistant to course assignments.&emsp;</td>
+            <td>
+            <form action="{% url 'algorithm' %}" method="post">
+            {% csrf_token %}
+            <div id="dialog-confirm" title="Confirm Action">
+            <p><span class="emailButtonPopupText"></span>Running the algorithm may take up to 1 minute. Are you sure?</p>
+            </div>
+                <input class="submitButton2Popup" type="submit" name="algo_run" value="Solve model"/>
+            </form>
+            </td>
+        </tr>
+        <tr>
+            <td>2. Export students without a position.&emsp;</td>
+            <td>
+            <form action="{% url 'algorithm' %}" method="post">
+            {% csrf_token %}
+                <input class="submitButton2" type="submit" name="student_export" value="Export students without a match"/>
+            </form>
+            </td>
+        </tr>
+        <tr>
+            <td>3. Export courses that still need teaching assistants.&emsp;</td>
+            <td>
+            <form action="{% url 'algorithm' %}" method="post">
+            {% csrf_token %}
+                <input class="submitButton2" type="submit" name="course_export" value="Export courses without a match"/>
+            </form>
+            </td>
+        </tr>
+        <tr>
+            <td>4. Export matching results.&emsp;</td>
+            <td>
+            <form action="{% url 'algorithm' %}" method="post">
+            {% csrf_token %}
+                <input class="submitButton2" type="submit" name="algo_export" value="Export last algorithm run"/>
+            </form>
+            </td>
+        </tr>
+    </table>
+</div>
 
 <br>
 {% if students_supply|length > 133 %}

--- a/taworks/taform/templates/taform/algorithm.html
+++ b/taworks/taform/templates/taform/algorithm.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 {% extends "taform/base.html" %}
 {% block content %}
 {% load static %}

--- a/taworks/taform/templates/taform/application.html
+++ b/taworks/taform/templates/taform/application.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 {% extends "taform/base.html" %}
 {% block content %}
 
@@ -202,51 +201,52 @@ To help instructors select TAs, please upload a CV or resume (PDF only):<br><br>
 <br>
 {% endfor %}
 
-<h2>Confirmation</h2>
-<div class="divWordWrap">
-    I fully understand that I can only submit one application per academic term, 
-    and that once the application is submitted, no changes or modifications of 
-    any sort can be done to my application.
-</div><br>
-<div class="divWordWrap">
-    In addition to the above information, an application for a teaching assistant 
-    position implies that the applicant agrees to the following conditions of 
-    employment, and gives the department permission to verify that the student 
-    meets these conditions via examination of the student record.
+<div id="confirm-boxes">
+    <h2>Confirmation</h2>
+    <div class="divWordWrap">
+        I fully understand that I can only submit one application per academic term, 
+        and that once the application is submitted, no changes or modifications of 
+        any sort can be done to my application.
+    </div><br>
+    <div class="divWordWrap">
+        In addition to the above information, an application for a teaching assistant 
+        position implies that the applicant agrees to the following conditions of 
+        employment, and gives the department permission to verify that the student 
+        meets these conditions via examination of the student record.
+    </div>
+    <div class="divWordWrap">
+    For full details on the Responsibilities and Requirements of a Management 
+    Sciences Teaching Assistantship please read in full 
+    <a target="_blank" href=https://uwaterloo.ca/management-sciences/graduate-students/teaching-assistantships-management-sciences>teaching assistantships management sciences</a>.
+    </div>
+    <br>
+        <table class="required">
+        <tr>
+            <td><input type="checkbox" class="number" value="One">
+            <td><label>&nbsp;I confirm that I do not have any outstanding English Language Proficiency requirements as part of my conditions of admission for my Graduate Studies program.</label>
+            </td>
+        </tr>
+        <tr>
+            <td><input type="checkbox" class="number" value="Two">
+            <td><label>&nbsp;I understand that as a Full-Time registered graduate students I am not permitted to be employed by the University for more than an average of (10) ten hours per week per term.</label>
+            </td>
+        </tr>
+        <tr>
+            <td><input type="checkbox" class="number" value="Three">
+            <td><label>&nbsp;I acknowledge that I will be available from the first day of the first month of the term to the last day of the last month of the term.</label>
+            </td>
+        </tr>
+        <tr>
+            <td><input type="checkbox" class="number" value="Four">
+            <td><label>&nbsp;I have read and understand fully the Responsibilities and Requirements of being a Management Sciences Teaching Assistant.</label>
+            </td>
+        </tr>
+    </table>
+
+    <p>To submit your application you must agree to the above terms.</p>
+
+    <p class="font">Please note you will not be able to make changes to your application once you submit.</p>
 </div>
-<div class="divWordWrap">
-For full details on the Responsibilities and Requirements of a Management 
-Sciences Teaching Assistantship please read in full 
-<a target="_blank" href=https://uwaterloo.ca/management-sciences/graduate-students/teaching-assistantships-management-sciences>teaching assistantships management sciences</a>.
-</div>
-<br>
-    <table class="required">
-    <tr>
-        <td><input type="checkbox" class="number" value="One">
-        <td><label>&nbsp;I confirm that I do not have any outstanding English Language Proficiency requirements as part of my conditions of admission for my Graduate Studies program.</label>
-        </td>
-    </tr>
-    <tr>
-        <td><input type="checkbox" class="number" value="Two">
-        <td><label>&nbsp;I understand that as a Full-Time registered graduate students I am not permitted to be employed by the University for more than an average of (10) ten hours per week per term.</label>
-        </td>
-    </tr>
-    <tr>
-        <td><input type="checkbox" class="number" value="Three">
-        <td><label>&nbsp;I acknowledge that I will be available from the first day of the first month of the term to the last day of the last month of the term.</label>
-        </td>
-    </tr>
-    <tr>
-        <td><input type="checkbox" class="number" value="Four">
-        <td><label>&nbsp;I have read and understand fully the Responsibilities and Requirements of being a Management Sciences Teaching Assistant.</label>
-        </td>
-    </tr>
-</table>
-
-<p>To submit your application you must agree to the above terms.</p>
-
-<p class="font">Please note you will not be able to make changes to your application once you submit.</p>
-
 <div id="app-confirm" title="Confirm Action">
     <p class="appButtonPopupText">Are you sure you want to submit this application?</p>
 </div>

--- a/taworks/taform/templates/taform/application.html
+++ b/taworks/taform/templates/taform/application.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 {% extends "taform/base.html" %}
 {% block content %}
 

--- a/taworks/taform/templates/taform/ranking_status.html
+++ b/taworks/taform/templates/taform/ranking_status.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 {% extends "taform/base.html" %}
 {% block content %}
 {% load static %}
@@ -36,7 +35,7 @@
 
 {% else %}
 <p>Rankings that have been submitted can still be edited by the AC. Click on the course link to view and edit Instructor rankings.</p>
-
+<div id="ranking"></div>
 <table class="tg">
 	<tr>
 	<th class="tg-8fvv">Course</th>

--- a/taworks/taform/templates/taform/ranking_status.html
+++ b/taworks/taform/templates/taform/ranking_status.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 {% extends "taform/base.html" %}
 {% block content %}
 {% load static %}


### PR DESCRIPTION
Solution as per the following stack over flow answer:

![image](https://user-images.githubusercontent.com/22123056/37187802-f6fe6ad8-2319-11e8-845d-a7eb63782b43.png)

By adding Doctype HTML, this removes the spacing in the course table:
![image](https://user-images.githubusercontent.com/22123056/37189505-c9c3fe44-2322-11e8-95e3-a74b314b9572.png)
See the first answer: https://stackoverflow.com/questions/32214152/why-does-my-div-height-100-work-only-when-doctype-is-removed
@j2kan @smwatts @amyleblond let me know what you think